### PR TITLE
Update plugin tools' vent.template with information about output piping from other tools

### DIFF
--- a/csv_row_broadcast/vent.template
+++ b/csv_row_broadcast/vent.template
@@ -4,3 +4,4 @@ groups = csv
 
 [settings]
 ext_types = csv
+process_base = yes

--- a/dshell_netflow_parser/vent.template
+++ b/dshell_netflow_parser/vent.template
@@ -5,3 +5,4 @@ groups = pcap
 [settings]
 mime_types = application/vnd.tcpdump.pcap
 ext_types = pcap
+process_base = yes

--- a/gpu_example/vent.template
+++ b/gpu_example/vent.template
@@ -9,3 +9,4 @@ device = 0
 
 [settings]
 ext_types = matrix
+process_base = yes

--- a/pcap_to_node_pcap/pcap_to_node_pcap.py
+++ b/pcap_to_node_pcap/pcap_to_node_pcap.py
@@ -2,10 +2,11 @@
 Plugin that takes pcap files and splits them by server and client
 ip addresses
 
-Create on 17 July 2017
+Created on 17 July 2017
 @author: Blake Pagon
 """
 
+import datetime
 import os
 import shlex
 import subprocess
@@ -22,17 +23,26 @@ def get_path():
 def run_tool(path):
     # need to make directories to store results from pcapsplitter
     base_dir = path.rsplit('/', 1)[0]
+    timestamp = ""
     try:
-        os.mkdir(base_dir + '/clients')
-        os.mkdir(base_dir + '/servers')
+        timestamp = '-'.join(str(datetime.datetime.now()).split(' ')) + '-UTC'
+        timestamp = timestamp.replace(':', '_')
+    except Exception as e:
+        print("couldn't create output directory with unique timestamp")
+    # make directory for tool name recognition of piping to other tools
+    output_dir = os.path.join(base_dir, 'pcap-node-splitter' + '-' + timestamp)
+    try:
+        os.mkdir(output_dir)
+        os.mkdir(output_dir + '/clients')
+        os.mkdir(output_dir + '/servers')
     except OSError:
-        print("clients and servers directories already exist")
+        print("couldn't make directories for output of this tool")
     try:
         subprocess.check_call(shlex.split("./PcapPlusPlus/Examples/PcapSplitter/Bin/PcapSplitter -f " + 
-                                          path + " -o " + base_dir + '/clients' + " -m client-ip"))
+                                          path + " -o " + output_dir + '/clients' + " -m client-ip"))
 
         subprocess.check_call(shlex.split("./PcapPlusPlus/Examples/PcapSplitter/Bin/PcapSplitter -f " + 
-                                          path + " -o " + base_dir + '/servers' + " -m server-ip"))
+                                          path + " -o " + output_dir + '/servers' + " -m server-ip"))
     except Exception as e:
         print(str(e))
 

--- a/pcap_to_node_pcap/vent.template
+++ b/pcap_to_node_pcap/vent.template
@@ -3,4 +3,5 @@ name = pcap node splitter
 groups = pcap
 
 [settings]
+mime_types = application/vnd.tcpdump.pcap
 ext_types = pcap

--- a/pcap_to_node_pcap/vent.template
+++ b/pcap_to_node_pcap/vent.template
@@ -5,3 +5,4 @@ groups = pcap
 [settings]
 mime_types = application/vnd.tcpdump.pcap
 ext_types = pcap
+process_base = yes

--- a/tcpdump_hex_parser/vent.template
+++ b/tcpdump_hex_parser/vent.template
@@ -5,3 +5,5 @@ groups = pcap
 [settings]
 mime_types = application/vnd.tcpdump.pcap
 ext_types = pcap
+process_base = yes
+process_from_tool = pcap node splitter


### PR DESCRIPTION
For now, I have defined it so that only tcp dump hex parser will look at the split files outputted by pcap to node splitter.