### PR TITLE
Remove deprecated MAINTAINER from Dockerfile

### DIFF
--- a/pcap_to_node_pcap/Dockerfile
+++ b/pcap_to_node_pcap/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
-MAINTAINER Blake Pagon <bpagon@iqt.org>
 
-LABEL vent = "" \
+LABEL maintainer = "Blake Pagon <bpagon@iqt.org>" \
+      vent = "" \
       vent.name = "node pcap" \
       vent.groups = "pcap"
 


### PR DESCRIPTION
closes #75 

Moved maintainer down with other labels.