### PR TITLE
virustotal support

### DIFF
--- a/check_files/Dockerfile
+++ b/check_files/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update; apt-get install -y \
     python3-dev \
     python-dev \
     python-pip \
+    virustotal \
     clamav \
     clamav-freshclam
 

--- a/check_files/Dockerfile
+++ b/check_files/Dockerfile
@@ -7,9 +7,12 @@ RUN apt-get update; apt-get install -y \
     python3-dev \
     python-dev \
     python-pip \
-    virustotal \
     clamav \
     clamav-freshclam
+
+COPY requirements.txt /
+RUN find . -name requirements.txt -type f -exec pip install -r {} \;
+
 
 RUN freshclam
 

--- a/check_files/requirements.txt
+++ b/check_files/requirements.txt
@@ -1,0 +1,1 @@
+virustotal-api

--- a/check_files/run.py
+++ b/check_files/run.py
@@ -77,7 +77,7 @@ def main(virus_key):
 
 if __name__ == "__main__":
     virus_key = os.getenv('VIRUS_TOTAL_API_KEY', 'UNCONFIGURED')
-    #print('av_key',virus_key)
+    print('av_key',virus_key[:4])
     if len(sys.argv) > 1:
         out = main(virus_key)
         retval = {'answer': out}

--- a/check_files/run.py
+++ b/check_files/run.py
@@ -49,31 +49,35 @@ def main(virus_key):
 
     # directory
     if os.path.isdir(starting_point):
+        #print('directory',starting_point)
         for root, dirnames, filenames in os.walk(starting_point):
             for filename in fnmatch.filter(filenames, '*'):
                 matches.append(os.path.join(root, filename))
     # single file
     if os.path.isfile(starting_point):
+        #print('file',starting_point)
         matches.append(starting_point)
 
     for match in matches:
         this_dict = {}
         av_result = av_results(match).split(':')[-1].strip()
         hash_result = hash_results(match)
-        this_dict['av_results'] = av_result
+        this_dict['clamav_results'] = av_result
         this_dict['hash_results'] = hash_result
         if v is not None:
             lookup = hash_result['md5']
             response = v.get_file_report(lookup)
-            this_dict['report'] = response
+            this_dict['virustotal_report'] = response
         else:
-            this_dict['report'] = None
+            this_dict['virustotal_report'] = None
+        ret_val[match]=this_dict 
 
     return ret_val
 
 
 if __name__ == "__main__":
     virus_key = os.getenv('VIRUS_TOTAL_API_KEY', 'UNCONFIGURED')
+    #print('av_key',virus_key)
     if len(sys.argv) > 1:
         out = main(virus_key)
         retval = {'answer': out}

--- a/check_files/run.py
+++ b/check_files/run.py
@@ -1,10 +1,10 @@
 #!/bin/env python
+from __future__ import print_function
 import fnmatch
 import os
 import sys
 import subprocess
 import hashlib
-from __future__ import print_function
 import json
 from virus_total_apis import PublicApi as VirusTotalPublicApi
 

--- a/check_files/vent.template
+++ b/check_files/vent.template
@@ -4,3 +4,6 @@ groups = cpu
 
 [settings]
 ext_types = exe
+
+[docker]
+environment = ["VIRUS_TOTAL_API_KEY=UNCONFIGURED"]


### PR DESCRIPTION
completed everything documented in:
> Running automated checks against incoming files, such as deliverables, by building a vent-plugin 
> MD5 checksum
> ClamAV virus scanning
> Checking against VirusTotal
